### PR TITLE
[시도_1_X] 지기성/치킨_배달.P.332; 한 가게-집 거리로 계산함

### DIFF
--- a/Implementation/이코테/치킨_배달-P.332.py
+++ b/Implementation/이코테/치킨_배달-P.332.py
@@ -1,0 +1,46 @@
+###
+# <기성> [X] : 로직이 틀림 ; 구현한 로직은 한 가게에서 집까지의 거리이지만, 요구사항은 집에서 가장 가까운 가게의 거리를 요구하는 것
+
+# 집 혹은 가게를 기준으로 거리1씩 늘리면서(?) [둘러싸는 사각형] 서치하려했으나
+# 가게 혹은 집의 위치를 저장하면 될듯?
+#
+# 집 ~ 가게 경우의 수(순열)만큼 거리 계산 (완전탐색) ; -> 다만 아래 로직은 조합의 경우의수로됐음
+# 거리: '가게 기준 집' 으로 정함
+# 가게 당 집까지 거리를 다 더함; 
+#
+# 가게 마다 거리 길이를 모아서 
+# 오름차순으로 정렬 후
+# m개 만큼 더함
+
+n, m = map(int, input().split())
+
+houses = []
+stores = []
+
+length_list_per_stores = []
+
+for row in range(n):
+    data = list(map(int, input().split()))
+    for column in range(n):
+        if data[column] == 1:
+            houses.append((row, column))
+        elif data[column] == 2:
+            stores.append((row, column))
+
+for store in stores:
+    store_row, store_column = store
+
+    length_list = []
+    for house in houses:
+        house_row, house_column = house
+
+        road_length = (abs(house_row - store_row) + abs(house_column - store_column))
+        length_list.append(road_length)
+    sum_road_length = sum(length_list)
+    # sum_road_length = 가게의 치킨거리
+    # 가게 마다의 치킨거리 비교를 위해
+    length_list_per_stores.append(sum_road_length)
+length_list_per_stores.sort()
+result = sum(length_list_per_stores[:m])
+print(result)
+###


### PR DESCRIPTION
 #### ⌗ 체감 난이도 (매우 어려움: 5)
 - [ ] 5
 - [ ] 4
 - [x] 3
 - [ ] 2
 - [ ] 1

 #### ⌗ 문제 풀이 정답 여부
 - [ ] 정답
 - [x] 오답

 #### ⌗ 본인 풀이 이해도 (로직 설명 가능: 5)
 - [ ] 5
 - [x] 4
 - [ ] 3
 - [ ] 2
 - [ ] 1

 #### ⌗ 리뷰 반영
 - [ ] 리뷰 반영

---

## ⌗ 문제 접근 방식 (장황하게 적어도 되나, 타인이 보아도 이해 가능한 정도까지는 정리해 주세요)
1. 집 혹은 가게를 기준으로 거리1씩 늘리면서(?) [둘러싸는 사각형] 서치하려했으나
2. 가게와 집의 위치를 저장해서 거리를 계산해서 비교하면 될 것 같음

## ⌗ 적용 알고리즘 유형
-  구현 (완전탐색)

## ⌗ 구현 로직 설명
1. 집 ~ 가게 경우의 수(순열)만큼 거리 계산 (완전탐색) ; -> 다만 로직은 조합의 경우의수로됐음
2. 거리: '가게 기준 집' 으로 정함
3. 가게 당 집까지 거리를 다 더함; 
4. 가게 마다 거리 길이를 모아서 
5. 오름차순으로 정렬 후
6. m개 만큼 더함

## ⌗ 블로커
- 생각한 로직의 구현자체 블로커는 없었음

## ⌗ 의문점
-

## ⌗ 개선 방향성
- 구현한 로직은 한 가게에서 집까지의 거리이지만, 
- 요구사항은 집에서 가장 가까운 가게의 거리를 요구하는 것
- 따라서 집에서 가장 가까운 가게의 거리를 구하는 로직을 짜야함

## ⌗ 기록해두고 싶은 부분
- 

## ⌗ 리뷰반영
- (예시) 리뷰를 반영하여 로직에 이러한 차이가 있었다.
